### PR TITLE
IONOS(build): switch runners from self-hosted to ubuntu-latest

### DIFF
--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -196,7 +196,7 @@ jobs:
           fi
 
   build-external-apps:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     needs: prepare-matrix
 
     permissions:
@@ -230,7 +230,7 @@ jobs:
           tools: composer:v2
           extensions: gd, zip, curl, xml, xmlrpc, mbstring, sqlite, xdebug, pgsql, intl, imagick, gmp, apcu, bcmath, redis, soap, imap, opcache
         env:
-          runner: self-hosted
+          runner: ubuntu-latest
 
       - name: Cache Composer dependencies for ${{ matrix.app.name }}
         if: matrix.app.has_composer
@@ -254,7 +254,7 @@ jobs:
             !${{ matrix.app.path }}/node_modules
 
   build-artifact:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     needs: [prepare-matrix, build-external-apps]
 
     permissions:
@@ -339,7 +339,7 @@ jobs:
           tools: composer:v2
           extensions: gd, zip, curl, xml, xmlrpc, mbstring, sqlite, xdebug, pgsql, intl, imagick, gmp, apcu, bcmath, redis, soap, imap, opcache
         env:
-          runner: self-hosted
+          runner: ubuntu-latest
 
       - name: Cache Composer dependencies
         uses: actions/cache@v4


### PR DESCRIPTION
## Summary

Till we get proper caching caching logic

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
