### PR TITLE
IONOS(build): update GitLab trigger to use BUILD_TYPE variable

### DIFF
--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -592,18 +592,21 @@ jobs:
     steps:
       - name: Trigger remote workflow
         run: |
-          # Enable command echo
+          # Enable command echo for debugging purposes
           set -x
 
-          # The 'ionos-dev' branch will trigger remote "dev" branch workflow
-          GITLAB_BRANCH="dev"
+          # Determine build type based on branch:
+          # - 'ionos-dev' branch triggers 'dev' build type
+          # - 'ionos-stable' branch triggers 'stable' build type
+          BUILD_TYPE="dev"
 
-          # set ARTIFACTORY_STAGE_PREFIX=stable on ionos-stable branch
-          if [ ${{ github.ref_name }} == "ionos-stable" ]; then
-              GITLAB_BRANCH="stable"
+          # Override build type for stable branch
+          if [ "${{ github.ref_name }}" == "ionos-stable" ]; then
+              BUILD_TYPE="stable"
           fi
 
-          # Call webhook
+          # Trigger GitLab pipeline via webhook with build artifacts and metadata
+          # Passes GitHub context variables to remote GitLab workflow
           curl \
           --silent \
           --insecure \
@@ -611,11 +614,12 @@ jobs:
           --fail-with-body \
           -o response.json \
           --form token=${{ secrets.GITLAB_TOKEN }} \
-          --form ref="${GITLAB_BRANCH}" \
+          --form ref="stable" \
           --form "variables[GITHUB_SHA]=${{ github.sha }}" \
           --form "variables[ARTIFACTORY_LAST_BUILD_PATH]=${{ needs.upload-to-artifactory.outputs.ARTIFACTORY_LAST_BUILD_PATH }}" \
           --form "variables[NC_VERSION]=${{ needs.build-artifact.outputs.NC_VERSION }}" \
           --form "variables[BUILD_ID]=${{ github.run_id }}" \
+          --form "variables[BUILD_TYPE]=${BUILD_TYPE}" \
           "${{ secrets.GITLAB_TRIGGER_URL }}" || ( RETCODE="$?"; jq . response.json; exit "$RETCODE" )
 
           # Disable command echo


### PR DESCRIPTION
use always "stable" branch as a trigger target

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
