### PR TITLE
fix(security): apply April 2026 security patch GHSA-hrrv-mp25-26vv

### DIFF
--- a/apps/dav/composer/composer/autoload_classmap.php
+++ b/apps/dav/composer/composer/autoload_classmap.php
@@ -73,6 +73,8 @@ return array(
     'OCA\\DAV\\CalDAV\\Outbox' => $baseDir . '/../lib/CalDAV/Outbox.php',
     'OCA\\DAV\\CalDAV\\Plugin' => $baseDir . '/../lib/CalDAV/Plugin.php',
     'OCA\\DAV\\CalDAV\\Principal\\Collection' => $baseDir . '/../lib/CalDAV/Principal/Collection.php',
+    'OCA\\DAV\\CalDAV\\Principal\\ProxyRead' => $baseDir . '/../lib/CalDAV/Principal/ProxyRead.php',
+    'OCA\\DAV\\CalDAV\\Principal\\ProxyWrite' => $baseDir . '/../lib/CalDAV/Principal/ProxyWrite.php',
     'OCA\\DAV\\CalDAV\\Principal\\User' => $baseDir . '/../lib/CalDAV/Principal/User.php',
     'OCA\\DAV\\CalDAV\\Proxy\\Proxy' => $baseDir . '/../lib/CalDAV/Proxy/Proxy.php',
     'OCA\\DAV\\CalDAV\\Proxy\\ProxyMapper' => $baseDir . '/../lib/CalDAV/Proxy/ProxyMapper.php',

--- a/apps/dav/composer/composer/autoload_static.php
+++ b/apps/dav/composer/composer/autoload_static.php
@@ -88,6 +88,8 @@ class ComposerStaticInitDAV
         'OCA\\DAV\\CalDAV\\Outbox' => __DIR__ . '/..' . '/../lib/CalDAV/Outbox.php',
         'OCA\\DAV\\CalDAV\\Plugin' => __DIR__ . '/..' . '/../lib/CalDAV/Plugin.php',
         'OCA\\DAV\\CalDAV\\Principal\\Collection' => __DIR__ . '/..' . '/../lib/CalDAV/Principal/Collection.php',
+        'OCA\\DAV\\CalDAV\\Principal\\ProxyRead' => __DIR__ . '/..' . '/../lib/CalDAV/Principal/ProxyRead.php',
+        'OCA\\DAV\\CalDAV\\Principal\\ProxyWrite' => __DIR__ . '/..' . '/../lib/CalDAV/Principal/ProxyWrite.php',
         'OCA\\DAV\\CalDAV\\Principal\\User' => __DIR__ . '/..' . '/../lib/CalDAV/Principal/User.php',
         'OCA\\DAV\\CalDAV\\Proxy\\Proxy' => __DIR__ . '/..' . '/../lib/CalDAV/Proxy/Proxy.php',
         'OCA\\DAV\\CalDAV\\Proxy\\ProxyMapper' => __DIR__ . '/..' . '/../lib/CalDAV/Proxy/ProxyMapper.php',

--- a/apps/dav/lib/CalDAV/Principal/ProxyRead.php
+++ b/apps/dav/lib/CalDAV/Principal/ProxyRead.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\DAV\CalDAV\Principal;
+
+use Sabre\DAVACL;
+
+class ProxyRead extends \Sabre\CalDAV\Principal\ProxyRead implements DAVACL\IACL {
+	use DAVACL\ACLTrait;
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getOwner() {
+		return $this->principalInfo['uri'];
+	}
+}

--- a/apps/dav/lib/CalDAV/Principal/ProxyWrite.php
+++ b/apps/dav/lib/CalDAV/Principal/ProxyWrite.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\DAV\CalDAV\Principal;
+
+use Sabre\DAVACL;
+
+class ProxyWrite extends \Sabre\CalDAV\Principal\ProxyWrite implements DAVACL\IACL {
+	use DAVACL\ACLTrait;
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getOwner() {
+		return $this->principalInfo['uri'];
+	}
+}

--- a/apps/dav/lib/CalDAV/Principal/User.php
+++ b/apps/dav/lib/CalDAV/Principal/User.php
@@ -33,4 +33,44 @@ class User extends \Sabre\CalDAV\Principal\User {
 		];
 		return $acl;
 	}
+
+	/**
+	 * Returns a specific child node, referenced by its name.
+	 *
+	 * @param string $name
+	 *
+	 * @return \Sabre\DAV\INode
+	 */
+	public function getChild($name) {
+		$principal = $this->principalBackend->getPrincipalByPath($this->getPrincipalURL() . '/' . $name);
+		if (!$principal) {
+			throw new \Sabre\DAV\Exception\NotFound("Node with name $name was not found");
+		}
+		if ($name === 'calendar-proxy-read') {
+			return new ProxyRead($this->principalBackend, $this->principalProperties);
+		}
+
+		if ($name === 'calendar-proxy-write') {
+			return new ProxyWrite($this->principalBackend, $this->principalProperties);
+		}
+
+		throw new \Sabre\DAV\Exception\NotFound("Node with name $name was not found");
+	}
+
+	/**
+	 * Returns an array with all the child nodes.
+	 *
+	 * @return \Sabre\DAV\INode[]
+	 */
+	public function getChildren() {
+		$r = [];
+		if ($this->principalBackend->getPrincipalByPath($this->getPrincipalURL() . '/calendar-proxy-read')) {
+			$r[] = new ProxyRead($this->principalBackend, $this->principalProperties);
+		}
+		if ($this->principalBackend->getPrincipalByPath($this->getPrincipalURL() . '/calendar-proxy-write')) {
+			$r[] = new ProxyWrite($this->principalBackend, $this->principalProperties);
+		}
+
+		return $r;
+	}
 }


### PR DESCRIPTION
## Summary

Applies the Nextcloud April 2026 security patch [GHSA-hrrv-mp25-26vv](https://cloud.nextcloud.com/s/s92tdRjZWWoP59Q) for Nextcloud 31.

### Fix 1 — CalDAV Principal Proxy exposure (`apps/dav`)

`OCA\DAV\CalDAV\Principal\User` inherited `getChild()` and `getChildren()` from Sabre's base class, which returned raw `Sabre\CalDAV\Principal\ProxyRead/ProxyWrite` objects without Nextcloud's ACL controls.

- Added `OCA\DAV\CalDAV\Principal\ProxyRead` and `ProxyWrite` wrapper classes
- Overrode `getChild()` and `getChildren()` in `User.php` to return these Nextcloud-namespaced instances
- Updated DAV composer autoload maps accordingly

### Fix 2 — Text app session auth bypass (`apps-external/text`)

`SessionMiddleware::assertUserOrShareToken()` checked user authentication **before** share token. An authenticated user supplying a share token could bypass share-level restrictions (e.g. `permissions.download = false`).

Updated `apps-external/text` submodule from `v31.0.8` → `stable31@f8e8e685a` (`v31.0.14-25`) which includes the upstream fix [783eab90f](https://github.com/nextcloud/text/commit/783eab90f18bbb302cb0e9b39eb51bb1700d359b) — "fix: always validate share token if provided".

## Test plan

- [x] Verify CalDAV calendar delegation still works (proxy read/write principals resolve correctly)
- [x] Verify Text app: authenticated user with a no-download share cannot access document via share token path
- [x] Verify Text app: unauthenticated user with valid share token can still access document
- [x] Run CI pipeline