### PR TITLE
IONOS(theming): fix user_saml login selector invisible in light mode

### DIFF
--- a/apps/theming/css/ionos/user-saml.css
+++ b/apps/theming/css/ionos/user-saml.css
@@ -1,0 +1,22 @@
+/*
+ * SPDX-FileCopyrightText: 2025 IONOS SE
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/*
+ * user_saml uses --color-primary-text (white, for text on primary-colored surfaces)
+ * for text and borders on the main background, making them invisible in light mode.
+ * Override with --color-main-text which is the correct variable for content on the
+ * main background.
+ */
+#saml-select-user-back-end {
+	color: var(--color-main-text);
+}
+
+.login-option {
+	border-color: var(--color-main-text);
+}
+
+.login-option a {
+	color: var(--color-main-text);
+}


### PR DESCRIPTION
user_saml uses --color-primary-text (white) for text and borders on the SAML backend selector page. NC's image background makes this work upstream, but IONOS uses a plain white background where white-on-white is invisible.

Override the affected selectors via the IONOS theming layer to keep the upstream user_saml app untouched and simplify future updates.

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: lightmode unredable text on select user backend page.

This bug in IONOS specific since the NC shows the text on a picture background. That's why opted to fix it in IONOS theme. 


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- see the steps to reproduce in [NSW-905](https://hosting-jira.1and1.org/browse/NSW-905)